### PR TITLE
Add missing dependency for 'requests' in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     keywords='Geocoder France',
     packages=['geocoding'],
-    install_requires=['numpy', 'Unidecode', 'KdQuery', 'sortedcontainers'],
+    install_requires=['numpy', 'Unidecode', 'KdQuery', 'sortedcontainers', 'requests'],
     entry_points={
         'console_scripts': [
             'geocoding = geocoding.__main__:main'


### PR DESCRIPTION
When installing `geocoding` using "pip" or "pipenv", install dependency for `requests` is missing. Thus the initial command `geocoding update` (or `geocoding download`) is failing.

This PR adds the missing `requests` dependency to "setup.py".

Example of git-based install:

```bash
pipenv install -e git+https://github.com/DeVilhena-Paulo/Geocoding#egg=geocoding
```